### PR TITLE
✨ feat(cors-configuration): frontend url cors설정 추가

### DIFF
--- a/docs/adr/007-configure-cors-policy.md
+++ b/docs/adr/007-configure-cors-policy.md
@@ -1,0 +1,76 @@
+---
+title: CORS 정책 수립 및 환경별 적용전략
+type: adr
+status: accepted
+tags: [security, cors, configuration, architecture]
+trigger_intent: CORS 정책의 수립 배경과 환경별 적용 기준을 파악할 때 이 문서를 참고한다.
+---
+
+# ADR-007: CORS 정책 수립 및 환경별 적용전략
+
+## Status
+
+Accepted
+
+## Date
+
+2026-02-05
+
+## Context
+
+`com.blaybus.backend` 서비스는 프론트엔드와 백엔드가 분리된 아키텍처를 따르고 있습니다. 브라우저의 보안 정책인 SOP(Same-Origin Policy)로 인해, 다른 도메인(Origin) 간의 리소스 요청 시 CORS(Cross-Origin Resource Sharing) 설정이 필수적입니다.
+
+특히 다음과 같은 요구사항을 고려해야 합니다.
+
+1. **인증 정보 공유**: 로그인 세션, 쿠키, Authorization 헤더 등을 주고받기 위해 `Access-Control-Allow-Credentials: true` 설정이 필요합니다.
+2. **보안성**: 개발 편의를 위해 모든 도메인(`*`)을 허용하는 것은 보안상 위험하며, `Allow-Credentials: true`와 함께 사용할 수 없습니다.
+3. **환경별 차이**: 로컬 개발 환경(`localhost`), 테스트 환경, 운영 환경의 도메인이 서로 다릅니다.
+
+## Decision
+
+**우리는 `dev`와 `prod` 프로파일을 활용하여 환경별로 명시적인 Origin을 관리하고, Spring Security 설정을 통해 이를 적용하기로 결정했습니다.**
+
+상세 전략은 다음과 같습니다:
+
+1. **명시적 Origin 허용**:
+   - 와일드카드(`*`) 사용을 금지하고, 신뢰할 수 있는 도메인만 명시적으로 허용합니다.
+   - 이는 `Allow-Credentials: true` 설정이 요구하는 사양이기도 합니다.
+
+2. **프로파일 기반 설정 분리**:
+   - `application-dev.yml`: 로컬 개발을 위한 `http://localhost:3000` 등 허용.
+   - `application-prod.yml`: 실제 운영 도메인(예: `https://blaybus.com`)만 허용.
+   - 설정값은 `app.cors.allowed-origins` 프로퍼티로 관리합니다.
+
+3. **엔드포인트별 정책 통일**:
+   - `CorsConfigurationSource` Bean을 정의하여 모든 Security Filter Chain에 전역적으로 적용합니다.
+
+## Trade-off Analysis
+
+### 1. 명시적 목록 관리 (선택됨)
+
+**장점 (Pros):**
+
+- **보안 강화**: 허용되지 않은 출처에서의 접근을 원천 차단하여 CSRF 등의 공격 위험을 줄임.
+- **표준 준수**: `Access-Control-Allow-Credentials` 사용 시의 브라우저 스펙 준수.
+- **가시성**: 어떤 도메인이 시스템에 접근 가능한지 설정 파일만 보고 파악 가능.
+
+**단점 (Cons):**
+
+- **운영 비용**: 프론트엔드 도메인이 변경되거나 추가될 때마다 백엔드 설정 변경 및 배포가 필요함.
+- **개발 번거로움**: 로컬 개발 시 디바이스 테스팅 등으로 Origin이 변경되면 설정을 수정해야 함.
+
+### 2. 와일드카드 (\*) 허용 (기각됨)
+
+**장점 (Pros):**
+
+- **편의성**: 어떤 도메인에서든 접근 가능하므로 초기 개발이 빠름.
+
+**단점 (Cons):**
+
+- **보안 취약**: 악의적인 사이트에서도 API 호출이 가능해짐.
+- **기능 제한**: `Allow-Credentials: true`를 사용할 수 없어 인증 기반 서비스에 부적합.
+
+## Consequences
+
+- 앞으로 프론트엔드 배포 URL이 생성되거나 변경될 때, 백엔드 담당자에게 해당 URL 등록을 요청해야 합니다.
+- CORS 관련 에러 발생 시, 우선적으로 `application-*.yml` 파일의 `allowed-origins` 목록을 확인해야 합니다.

--- a/src/main/java/com/blaybus/backend/config/SecurityConfig.java
+++ b/src/main/java/com/blaybus/backend/config/SecurityConfig.java
@@ -1,24 +1,48 @@
 package com.blaybus.backend.config;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+	@Value("${app.cors.allowed-origins}")
+	private List<String> allowedOrigins;
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.csrf(AbstractHttpConfigurer::disable)
+			.cors(Customizer.withDefaults())
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/health-check", "/actuator/prometheus").permitAll()
 				.anyRequest().authenticated());
 
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(allowedOrigins);
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,3 +24,7 @@ logging:
       file-name-pattern: logs/archived/backend-dev-%d{yyyy-MM-dd}.%i.log
       max-file-size: 10MB
       max-history: 30 # 30일이 지난 로그는 자동 삭제
+
+app:
+  cors:
+    allowed-origins: http://localhost:3000

--- a/src/test/java/com/blaybus/backend/config/SecurityConfigTest.java
+++ b/src/test/java/com/blaybus/backend/config/SecurityConfigTest.java
@@ -1,0 +1,44 @@
+package com.blaybus.backend.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"dev", "prod"})
+class SecurityConfigTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("CORS 설정에 등록된 Origin으로 요청 시 Access-Control-Allow-Origin 헤더가 반환되어야 한다")
+	void shouldReturnAllowOriginHeaderForAllowedOrigin() throws Exception {
+		mockMvc.perform(options("/health-check")
+			.header("Origin", "http://localhost:3000")
+			.header("Access-Control-Request-Method", "GET"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"))
+			.andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 Origin으로 요청 시 Access-Control-Allow-Origin 헤더가 반환되지 않아야 한다")
+	void shouldNotReturnAllowOriginHeaderForUnallowedOrigin() throws Exception {
+		mockMvc.perform(options("/health-check")
+			.header("Origin", "http://unallowed-origin.com")
+			.header("Access-Control-Request-Method", "GET"))
+			.andExpect(status().isForbidden());
+	}
+}


### PR DESCRIPTION
## 1. 📄 작업 내용 (Summary & Intent)
- frontend endpoint가 공개됨에 따라서 서로 다른 origin에 있는 프론트엔드 호스트에 대한 cors 설정
## 2. ✅ 테스트 계획 및 결과 (Testing Plan)
- 테스트 코드 참고
## 3. 💬 리뷰어에게 요청하는 점 (To Reviewers)
- `application-prod.yml` 파일을 추가해주세요
